### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: master


### PR DESCRIPTION
Potential fix for [https://github.com/sibiraj-s/coffeelint-reporter/security/code-scanning/1](https://github.com/sibiraj-s/coffeelint-reporter/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key to restrict the `GITHUB_TOKEN` to the minimum required privileges. For a typical test workflow that only checks out code and runs tests, `contents: read` is sufficient. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best way is to add the following block near the top of the workflow file, after the `name` and before `on` or `jobs`:

```yaml
permissions:
  contents: read
```

This ensures that the workflow and all jobs within it only have read access to repository contents, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
